### PR TITLE
Generate a single, flat "sdk.rs" 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 Cargo.lock
-src/sdk/
 .vs
+src/sdk.rs

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
 Cargo.lock
 src/sdk/
-.vs/ProjectSettings.json
-.vs/slnx.sqlite
+.vs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ incremental = false
 lto = "fat"
 panic = "abort"
 
+[features]
+include_sdk = []
+
 [dependencies]
 codegen = "0.1.3"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,10 @@ codegen = "0.1.3"
 log = "0.4"
 simplelog = "0.7"
 thiserror = "1.0"
-typed-builder = "0.6"
 wchar = "0.6"
 winapi = { version = "0.3", features = [
     "consoleapi",
     "libloaderapi",
-    "memoryapi", # not used
     "minwindef",
     "processthreadsapi",
     "psapi",

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -311,7 +311,7 @@ unsafe fn write_enumeration(sdk: &mut Scope, object: *const Object) -> Result<()
         return Ok(());
     }
 
-    let e = sdk.new_enum(name).repr("u8").vis("pub");
+    let enum_gen = sdk.new_enum(name).repr("u8").vis("pub");
 
     let object: *const Enum = object.cast();
 
@@ -323,13 +323,13 @@ unsafe fn write_enumeration(sdk: &mut Scope, object: *const Object) -> Result<()
 
         if let Some(prev) = previous {
             if prev == variant {
-                e.new_variant(&format!("{}_{}", prev, count));
+                enum_gen.new_variant(&format!("{}_{}", prev, count));
                 count += 1;
             } else {
                 if count > 0 {
-                    e.new_variant(&format!("{}_{}", prev, count));
+                    enum_gen.new_variant(&format!("{}_{}", prev, count));
                 } else {
-                    e.new_variant(prev);
+                    enum_gen.new_variant(prev);
                 }
                 previous = Some(variant);
                 count = 0;
@@ -342,10 +342,13 @@ unsafe fn write_enumeration(sdk: &mut Scope, object: *const Object) -> Result<()
 
     if let Some(previous) = previous {
         if count > 0 {
-            e.new_variant(&format!("{}_{}", previous, count));
+            enum_gen.new_variant(&format!("{}_{}", previous, count));
         } else {
-            e.new_variant(previous);
+            enum_gen.new_variant(previous);
         }
+        }
+
+    Ok(())
     }
 
     Ok(())

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -288,7 +288,7 @@ unsafe fn write_constant(sdk: &mut Scope, object: *const Object) -> Result<(), E
 }
 
 unsafe fn write_enumeration(sdk: &mut Scope, object: *const Object) -> Result<(), Error> {
-    let e = sdk.new_enum(name(object)?).repr("u8");
+    let e = sdk.new_enum(name(object)?).repr("u8").vis("pub");
 
     let object: *const Enum = object.cast();
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -294,7 +294,13 @@ unsafe fn write_constant(sdk: &mut Scope, object: *const Object) -> Result<(), E
 }
 
 unsafe fn write_enumeration(sdk: &mut Scope, object: *const Object) -> Result<(), Error> {
-    let e = sdk.new_enum(name(object)?).repr("u8").vis("pub");
+    let name = name(object)?;
+
+    if name.starts_with("Default__") {
+        return Ok(());
+    }
+
+    let e = sdk.new_enum(name).repr("u8").vis("pub");
 
     let object: *const Enum = object.cast();
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -222,6 +222,8 @@ pub unsafe fn sdk() -> Result<(), Error> {
     let mut sdk = File::create(SDK_PATH).map(BufWriter::new)?;
     let mut scope = Scope::new();
 
+    add_crate_attributes(&mut scope);
+
     for object in (*GLOBAL_OBJECTS).iter() {
         write_object(&mut scope, object)?;
     }
@@ -229,6 +231,10 @@ pub unsafe fn sdk() -> Result<(), Error> {
     writeln!(&mut sdk, "{}", scope.to_string())?;
 
     Ok(())
+}
+
+fn add_crate_attributes(scope: &mut Scope) {
+    scope.raw("#![allow(non_camel_case_types)]");
 }
 
 unsafe fn find_static_classes() -> Result<(), Error> {

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -285,22 +285,6 @@ fn add_deref_impls(sdk: &mut Scope, derived_name: &str, base_name: &str) {
         .line("&mut self.base");
 }
 
-/*
-impl Deref for Derived {
-    type Target = Base;
-
-    fn deref(&self) -> &Self::Target {
-        &self.base
-    }
-}
-
-impl DerefMut for Derived {
-    fn deref(&mut self) -> &mut Self::Target {
-        &mut self.base
-    }
-}
-*/
-
 unsafe fn get_properties(structure: *const Struct) -> Vec<&'static Property> {
     let properties = iter::successors(
         (*structure).children.cast::<Property>().as_ref(),

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -234,8 +234,8 @@ pub unsafe fn sdk() -> Result<(), Error> {
 }
 
 fn add_crate_attributes(scope: &mut Scope) {
-    scope.raw("#![allow(dead_code)]");
-    scope.raw("#![allow(non_camel_case_types)]");
+    scope.raw("#![allow(dead_code)]\n\
+               #![allow(non_camel_case_types)]");
 }
 
 unsafe fn find_static_classes() -> Result<(), Error> {

--- a/src/game.rs
+++ b/src/game.rs
@@ -206,11 +206,10 @@ pub struct Enum {
 }
 
 impl Enum {
-    pub unsafe fn variants(&self) -> Option<Vec<&str>> {
+    pub unsafe fn variants(&self) -> impl Iterator<Item = Option<&str>> {
         self.variants
             .iter()
             .map(|n| n.name())
-            .collect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ use module::Module;
 mod timeit;
 use timeit::TimeIt;
 
+#[cfg(feature = "include_sdk")]
+mod sdk;
+
 pub static mut GLOBAL_NAMES: *const Names = ptr::null();
 pub static mut GLOBAL_OBJECTS: *const Objects = ptr::null();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,8 @@ unsafe fn find_globals() -> Result<(), Error> {
 
 unsafe fn run() -> Result<(), Error> {
     find_globals()?;
-    dump::names()?;
-    dump::objects()?;
+    // dump::names()?;
+    // dump::objects()?;
     dump::sdk()?;
     Ok(())
 }


### PR DESCRIPTION
The master branch generates an SDK that has one Rust source file per structure. The generator organizes these files according to their two top-level game modules, e.g., we'll find the definition for `struct Vector` in `Core/Object/Vector.rs`

I don't like this organization for the SDK for several reasons:

1. We have to include a `mod.rs` at each level in the hierarchy, declaring each module, submodule, struct, class, and enum. It's easy enough to generate this `mod.rs` (master branch already does it), but it's strange to have this additional overhead when all the structure files are already laid out according to the directory hierarchy.
2. It's somewhat difficult to quickly search for a specific field of a structure without knowing the structure's name.
3. We have to manage the creation and reuse of files during the generation process.
4. Types in one module must refer to types in another module by fully qualifying the type name. Fields that look like `crate::sdk::Core::Object::Vector` as opposed to `Vector` are too verbose.

So I started working on a `flat_sdk` branch that stuffs all the constants, enums, and structs (classes and methods to come) of the entire game into a single, flat `sdk.rs`. The "flat" here means that there are no submodules within the generated SDK so that all types are exposed in the namespace of the single `sdk` module. Then, to include the SDK into a project, one simply has to copy the `sdk.rs` to the appropriate source folder and declare `mod sdk`.

The biggest disadvantage of this approach has been name conflicts. I've found so far two enums and three structures that share the same name but belong in different game modules and submodules. I'm currently ignoring the generation of these items until I figure out if/how I want to disambiguate their names.