### PR TITLE
Emit field offsets

### DIFF
--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -351,7 +351,7 @@ fn scrub_reserved_name(name: &str) -> &str {
 unsafe fn add_padding(struct_gen: &mut StructGen, offset: u32, size: u32) {
     let name = format!("pad_at_{:#x}", offset);
     let typ = format!("[u8; {:#x}]", size);
-    struct_gen.field(&name, typ);
+    emit_field(struct_gen, &name, typ, offset, size);
 }
 
 fn add_deref_impls(sdk: &mut Scope, derived_name: &str, base_name: &str) {

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -217,9 +217,8 @@ unsafe fn write_structure(sdk: &mut Scope, object: *const Object) -> Result<(), 
         None
     } else {
         offset = (*super_class).property_size.into();
-
         let super_name = helper::get_name(super_class.cast())?;
-        struct_gen.field("base", super_name);
+        emit_field(struct_gen, "base", super_name, 0, offset);
         Some(super_name)
     };
 


### PR DESCRIPTION
Closes #4.

We now emit `offset(length)` comments for each structure field.

```rust
#[repr(C)]
pub struct HUD {

    // 0x0(0x188)
    base: Actor,

    // 0x188(0x4)
    pub WhiteColor: Color,

    // 0x18c(0x4)
    pub GreenColor: Color,

    // 0x190(0x4)
    pub RedColor: Color,

    // 0x194(0x4)
    pub PlayerOwner: Option<&'static mut PlayerController>,

    // 0x198(0x4)
    pub AnimDebugThis: Option<&'static mut Actor>,

    // 0x19c(0x8)
    pub AnimDebugStartingPoint: NameIndex,

    // 0x1a4(0x4)
    pub bitfield: u32,

    // 0x1a8(0x4)
    pub HudCanvasScale: f32,

    ...
}
```