### PR TITLE
Normalize enum variant names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ panic = "abort"
 
 [features]
 default = ["hook"]
+#default = ["dump"]
 dump = ["codegen", "heck"]
 hook = ["detours-sys"]
 

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -226,19 +226,12 @@ unsafe fn write_enumeration(sdk: &mut Scope, object: *const Object) -> Result<()
     let variants = variants?;
 
     let common_prefix_len = if let Some(common_prefix) = common_prefix {
-        if variants.len() <= 1 {
-            // If there are fewer than two variants in the enum, there isn't a
-            // "common" prefix to strip.
-            0
-        } else {
-            // Get the total number of bytes that we need to skip the common
-            // prefix for each variant name.
-            let num_underscores = common_prefix.len();
+        // Get the total number of bytes that we need to skip the common
+        // prefix for each variant name.
+        let num_underscores = common_prefix.len();
+        let len: usize = common_prefix.iter().map(|component| component.len()).sum();
 
-            let len: usize = common_prefix.iter().map(|component| component.len()).sum();
-
-            num_underscores + len
-        }
+        num_underscores + len
     } else {
         // If we haven't initialized the common prefix, then there are no
         // variants in the enum. We don't generate empty enums.
@@ -258,7 +251,7 @@ unsafe fn write_enumeration(sdk: &mut Scope, object: *const Object) -> Result<()
             .filter(|stripped| {
                 let begins_with_number = stripped.as_bytes()[0].is_ascii_digit();
                 let is_self = *stripped == "Self";
-                
+
                 !begins_with_number && !is_self
             })
             .unwrap_or(&variant);

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -2,6 +2,7 @@ use crate::game::{cast, BoolProperty, Class, Const, Enum, Object, Property, Stru
 use crate::TimeIt;
 use crate::{GLOBAL_NAMES, GLOBAL_OBJECTS};
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -12,6 +13,7 @@ use std::iter;
 use std::ptr;
 
 use codegen::{Field, Scope, Struct as StructGen, Type};
+use heck::CamelCase;
 use log::info;
 use thiserror::Error;
 
@@ -187,28 +189,73 @@ unsafe fn write_enumeration(sdk: &mut Scope, object: *const Object) -> Result<()
         }
     }
 
-    let name = helper::resolve_duplicate(object)?;
-
-    if name.starts_with("Default__") {
-        return Ok(());
-    }
-
-    let enum_gen = sdk.new_enum(&name).repr("u8").vis("pub");
-
     let object: *const Enum = object.cast();
 
     let mut counts: HashMap<&str, usize> = HashMap::new();
+    let mut common_prefix: Option<Vec<&str>> = None;
 
-    for variant in (*object).variants() {
-        let variant = variant.ok_or(Error::BadVariant(object))?;
+    let variants: Result<Vec<Cow<str>>, Error> = (*object)
+        .variants()
+        .map(|variant| {
+            let variant = variant.ok_or(Error::BadVariant(object))?;
 
-        let count = counts.entry(variant).and_modify(|c| *c += 1).or_default();
+            if let Some(common_prefix) = common_prefix.as_mut() {
+                // Shrink the common prefix to the number of components still matching.
+                let num_components_matching = common_prefix
+                    .iter()
+                    .zip(variant.split('_'))
+                    .take_while(|(cp, s)| *cp == s)
+                    .count();
 
-        if *count == 0 {
-            enum_gen.new_variant(variant);
+                common_prefix.truncate(num_components_matching);
+            } else {
+                // All of the first variant will be the common prefix.
+                common_prefix = Some(variant.split('_').collect());
+            }
+
+            let count = counts.entry(variant).and_modify(|c| *c += 1).or_default();
+
+            if *count == 0 {
+                Ok(variant.into())
+            } else {
+                Ok(format!("{}_{}", variant, *count).into())
+            }
+        })
+        .collect();
+
+    let variants = variants?;
+
+    let common_prefix_len = if let Some(common_prefix) = common_prefix {
+        if variants.len() <= 1 || common_prefix.is_empty() {
+            // If there are fewer than two variants in the enum, there isn't a
+            // "common" prefix to strip.
+
+            // Likewise, if a common prefix doesn't exist among all the
+            // variants, then there's nothing to strip.
+            0
         } else {
-            enum_gen.new_variant(&format!("{}_{}", variant, *count));
+            // Get the total number of bytes that we need to skip the common
+            // prefix for each variant name.
+            let num_underscores = common_prefix.len() - 1;
+
+            let len: usize = common_prefix.iter().map(|component| component.len()).sum();
+
+            num_underscores + len
         }
+    } else {
+        // If we haven't initialized the common prefix, then there are no
+        // variants in the enum. We don't generate empty enums.
+        return Ok(());
+    };
+
+    let enum_gen = sdk
+        .new_enum(&helper::resolve_duplicate(object.cast())?)
+        .repr("u8")
+        .vis("pub");
+
+    for variant in variants {
+        let variant = &variant[common_prefix_len..];
+        enum_gen.new_variant(&variant.to_camel_case());
     }
 
     Ok(())


### PR DESCRIPTION
Closes #9 .

Strips prefixes from enum variants and normalizes the case to `PascalCase`.

Enum variants that become invalid Rust identifiers after stripping will retain their prefixes, but the case of the variant still gets normalized to `PascalCase`.

## Examples of generated enums

### All the variants no longer have a common prefix:
```rust
#[repr(u8)]
pub enum ECsgOper {
    Active,
    Add,
    Subtract,
    Intersect,
    Deintersect,
    Max,
}
```

### A variant named `Self` after stripping still retains its prefix:

```rust
#[repr(u8)]
pub enum EBehaviorContext {
    BcontextSelf, // Compiler error if variant was simply called `Self`
    MyInstigator,
    OtherEventParticipant,
    EventData,
    UseContextObject,
    Max,
}
```

### A variant that begins with a number after stripping still retains its prefix:
```rust
#[repr(u8)]
pub enum ESliderType {
    St1d, // This and the following variant would not compile if they were called "1d" and "2d" respectively.
    St2d,
    Max,
}
```

### A variant that becomes an empty string after stripping still retains its prefix:
```rust
#[repr(u8)]
pub enum EBehaviorCounterID {
    Bcounter, // The prefix is "Bcounter", but removing that prefix leaves an empty string.
    Bcounter1, // Incidentally, another example of retaining the prefix because the stripped version begins with a number.
    Max,
}
```