### PR TITLE
Emit methods

### DIFF
--- a/journal/20200711.txt
+++ b/journal/20200711.txt
@@ -1,0 +1,16 @@
+Emitting class methods:
+    [x] Emit `impl` block
+
+    [x] Emit method name
+    
+    [] Emit method arguments
+        [] Primitives
+        [] Bool special case
+        [] Optional Parameters
+        [] Out Parameters
+        [] Arrays
+    
+    [] Emit method return type
+    
+    [] Call ProcessEvent
+        []

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -349,19 +349,21 @@ unsafe fn get_properties(structure: *const Struct, offset: u32) -> Vec<&'static 
         .filter(|p| !p.is(STRUCTURE) && !p.is(CONSTANT) & !p.is(ENUMERATION) && !p.is(FUNCTION))
         .collect();
 
-    properties.sort_by(|p, q| {
-        p.offset.cmp(&q.offset).then_with(|| {
-            if p.is(BOOL_PROPERTY) && q.is(BOOL_PROPERTY) {
-                let p: &BoolProperty = cast(p);
-                let q: &BoolProperty = cast(q);
-                p.bitmask.cmp(&q.bitmask)
-            } else {
-                Ordering::Equal
-            }
-        })
-    });
+    properties.sort_by(|p, q| property_compare(p, q));
 
     properties
+}
+
+unsafe fn property_compare(p: &Property, q: &Property) -> Ordering {
+    p.offset.cmp(&q.offset).then_with(|| {
+        if p.is(BOOL_PROPERTY) && q.is(BOOL_PROPERTY) {
+            let p: &BoolProperty = cast(p);
+            let q: &BoolProperty = cast(q);
+            p.bitmask.cmp(&q.bitmask)
+        } else {
+            Ordering::Equal
+        }
+    })
 }
 
 unsafe fn add_fields(

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -583,7 +583,7 @@ unsafe fn add_method(impl_gen: &mut Impl, method_name_counts: &mut HashMap<&str,
     let method_gen = impl_gen
         .new_fn(&name)
         .vis("pub unsafe")
-        .line("static mut FUNCTION: Option<*mut Function> = None;\n")
+        .line("static mut FUNCTION: Option<*mut game::Function> = None;\n")
         .arg_mut_self();
 
     let parameters = Parameters::try_from(method)?;

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -133,7 +133,8 @@ unsafe fn find_static_classes() -> Result<(), Error> {
 
 fn add_crate_attributes(scope: &mut Scope) {
     scope.raw(
-        "#![allow(clippy::doc_markdown)]\n\
+        "#![allow(bindings_with_variant_name)]\n\
+         #![allow(clippy::doc_markdown)]\n\
          #![allow(dead_code)]\n\
          #![allow(non_camel_case_types)]\n\
          #![allow(non_snake_case)]",

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -527,6 +527,7 @@ unsafe fn write_class(sdk: &mut Scope, object: *const Object) -> Result<(), Erro
 
         let function_gen = impl_gen
             .new_fn(&function_name)
+            .vis("pub unsafe")
             .arg_mut_self();
 
         let flags = function.flags;

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ffi::OsString;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::ptr;
 
@@ -102,7 +102,6 @@ pub unsafe fn sdk() -> Result<(), Error> {
 
     find_static_classes()?;
 
-    let mut sdk = File::create(SDK_PATH)?;
     let mut scope = Scope::new();
 
     add_crate_attributes(&mut scope);
@@ -112,7 +111,7 @@ pub unsafe fn sdk() -> Result<(), Error> {
         write_object(&mut scope, object)?;
     }
 
-    writeln!(&mut sdk, "{}", scope.to_string())?;
+    fs::write(SDK_PATH, scope.to_string())?;
 
     Ok(())
 }

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -636,7 +636,7 @@ unsafe fn add_method(impl_gen: &mut Impl, method_name_counts: &mut HashMap<&str,
         let mut idents = String::from("\nSome((");
         let mut ret = String::from("Option<(");
 
-        for (ident, typ) in return_tuple.iter() {
+        for (ident, typ) in &return_tuple {
             idents.push_str(ident);
             idents.push_str(", ");
 

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -628,34 +628,39 @@ unsafe fn add_method(impl_gen: &mut Impl, method_name_counts: &mut HashMap<&str,
 
     if_block.line("(*function).flags = old_flags;");
 
-    if return_tuple.len() == 1 {
-        let (ident, typ) = &return_tuple[0];
-        if_block.line(format!("\nSome({})", ident));
-        method_gen.ret(format!("Option<{}>", typ));
-    } else if return_tuple.len() > 1 {
-        let mut idents = String::from("\nSome((");
-        let mut ret = String::from("Option<(");
+    match &return_tuple[..] {
+        [] => (),
 
-        for (ident, typ) in &return_tuple {
-            idents.push_str(ident);
-            idents.push_str(", ");
-
-            ret.push_str(typ);
-            ret.push_str(", ");
+        [(ident, typ)] => {
+            if_block.line(format!("\nSome({})", ident));
+            method_gen.ret(format!("Option<{}>", typ));
         }
 
-        // Remove trailing ", "
-        idents.pop();
-        idents.pop();
-
-        ret.pop();
-        ret.pop();
-
-        idents.push_str("))");
-        ret.push_str(")>");
-
-        if_block.line(idents);
-        method_gen.ret(ret);
+        _ => {
+            let mut idents = String::from("\nSome((");
+            let mut ret = String::from("Option<(");
+        
+            for (ident, typ) in &return_tuple {
+                idents.push_str(ident);
+                idents.push_str(", ");
+        
+                ret.push_str(typ);
+                ret.push_str(", ");
+            }
+        
+            // Remove trailing ", "
+            idents.pop();
+            idents.pop();
+        
+            ret.pop();
+            ret.pop();
+        
+            idents.push_str("))");
+            ret.push_str(")>");
+        
+            if_block.line(idents);
+            method_gen.ret(ret);
+        }
     }
 
     if_block.after(" else");

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -9,7 +9,6 @@ use std::convert::TryFrom;
 use std::ffi::OsString;
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
-use std::iter;
 use std::ptr;
 
 use codegen::{Field, Scope, Struct as StructGen, Type};
@@ -343,12 +342,8 @@ unsafe fn write_structure(sdk: &mut Scope, object: *const Object) -> Result<(), 
 }
 
 unsafe fn get_properties(structure: *const Struct, offset: u32) -> Vec<&'static Property> {
-    let properties = iter::successors(
-        (*structure).children.cast::<Property>().as_ref(),
-        |property| property.next.cast::<Property>().as_ref(),
-    );
-
-    let mut properties: Vec<&Property> = properties
+    let mut properties: Vec<&Property> = (*structure)
+        .iter_children()
         .filter(|p| p.element_size > 0)
         .filter(|p| p.offset >= offset)
         .filter(|p| !p.is(STRUCTURE) && !p.is(CONSTANT) & !p.is(ENUMERATION) && !p.is(FUNCTION))

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -556,7 +556,15 @@ impl<'a> TryFrom<&'a Function> for Parameters<'a> {
             let name = helper::get_name(parameter as &Object)?;
             let name = scrub_reserved_name(name);
             let name = get_unique_name(&mut parameter_name_counts, name);
-            let typ = PropertyInfo::try_from(parameter)?.into_typed_comment();
+            let mut typ = PropertyInfo::try_from(parameter)?.into_typed_comment();
+
+            if typ == "u32" {
+                // Special case: Apparently `BoolProperty` is "u32" in
+                // structure/class definitions, but "bool" when in method
+                // parameters.
+                typ = "bool".into();
+            }
+
             ret.0.push(Parameter { property: parameter, kind, name, typ });
         }
 

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -145,6 +145,7 @@ fn add_imports(scope: &mut Scope) {
     scope.raw(
         "use crate::game::{self, Array, FString, NameIndex, ScriptDelegate, ScriptInterface};\n\
          use crate::hook::bitfield::{is_bit_set, set_bit};\n\
+         use std::mem::MaybeUninit;\n\
          use std::ops::{Deref, DerefMut};",
     );
 }

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -574,7 +574,7 @@ unsafe fn add_method(impl_gen: &mut Impl, method_name_counts: &mut HashMap<&str,
     let method_gen = impl_gen
         .new_fn(&name)
         .vis("pub unsafe")
-        .line("static mut FUNCTION: Option<*mut Function> = None;")
+        .line("static mut FUNCTION: Option<*mut Function> = None;\n")
         .arg_mut_self();
 
     let parameters = Parameters::try_from(method)?;

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -48,7 +48,7 @@ pub enum Error {
     PropertyInfo(#[from] property_info::Error),
 
     #[error("property size mismatch of {1} bytes for {0:?}; info = {2:?}")]
-    PropertySizeMismatch(*const Property, u32, PropertyInfo),
+    PropertySizeMismatch(*const Property, i64, PropertyInfo),
 
     #[error("failed to convert OsString \"{0:?}\" to String")]
     StringConversion(OsString),
@@ -383,9 +383,10 @@ unsafe fn add_fields(
         let info = PropertyInfo::try_from(property)?;
 
         let total_property_size = property.element_size * property.array_dim;
-        let size_mismatch = total_property_size - info.size * property.array_dim;
+        
+        let size_mismatch = i64::from(total_property_size) - i64::from(info.size * property.array_dim);
 
-        if size_mismatch > 0 {
+        if size_mismatch != 0 {
             return Err(Error::PropertySizeMismatch(property, size_mismatch, info));
         }
 

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -413,11 +413,7 @@ unsafe fn add_fields(
             }
         };
 
-        let mut field_type = if info.comment.is_empty() {
-            info.field_type
-        } else {
-            format!("{} /* {} */", info.field_type, info.comment).into()
-        };
+        let mut field_type = info.as_typed_comment();
 
         if property.array_dim > 1 {
             field_type = format!("[{}; {}]", field_type, property.array_dim).into();

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -587,7 +587,7 @@ unsafe fn add_method(impl_gen: &mut Impl, method_name_counts: &mut HashMap<&str,
     Ok(())
 }
 
-unsafe fn get_unique_name<'a>(name_counts: &mut HashMap<&'a str, u8>, name: &'a str) -> Cow<'a, str> {
+fn get_unique_name<'a>(name_counts: &mut HashMap<&'a str, u8>, name: &'a str) -> Cow<'a, str> {
     let count = *name_counts
         .entry(name)
         .and_modify(|c| *c += 1)

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -522,7 +522,7 @@ enum ParameterKind {
 }
 
 struct Parameter<'a> {
-    parameter: &'a Property,
+    property: &'a Property,
     kind: ParameterKind,
     name: Cow<'a, str>,
     typ: Cow<'a, str>,
@@ -555,10 +555,10 @@ impl<'a> TryFrom<&'a Function> for Parameters<'a> {
             let name = helper::get_name(parameter as &Object)?;
             let name = get_unique_name(&mut parameter_name_counts, name);
             let typ = PropertyInfo::try_from(parameter)?.into_typed_comment();
-            ret.0.push(Parameter { parameter, kind, name, typ });
+            ret.0.push(Parameter { property: parameter, kind, name, typ });
         }
 
-        ret.0.sort_by(|p, q| property_compare(p.parameter, q.parameter));
+        ret.0.sort_by(|p, q| property_compare(p.property, q.property));
 
         Ok(ret)
     }}

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -553,6 +553,7 @@ impl<'a> TryFrom<&'a Function> for Parameters<'a> {
             };
 
             let name = helper::get_name(parameter as &Object)?;
+            let name = scrub_reserved_name(name);
             let name = get_unique_name(&mut parameter_name_counts, name);
             let typ = PropertyInfo::try_from(parameter)?.into_typed_comment();
             ret.0.push(Parameter { property: parameter, kind, name, typ });

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -323,7 +323,7 @@ unsafe fn write_structure(sdk: &mut Scope, object: *const Object) -> Result<(), 
         struct_gen.doc(&doc);
     }
 
-    let properties = get_properties(structure, offset);
+    let properties = get_fields(structure, offset);
     let bitfields = add_fields(struct_gen, &mut offset, properties)?;
 
     if offset < structure_size {
@@ -341,7 +341,7 @@ unsafe fn write_structure(sdk: &mut Scope, object: *const Object) -> Result<(), 
     Ok(())
 }
 
-unsafe fn get_properties(structure: *const Struct, offset: u32) -> Vec<&'static Property> {
+unsafe fn get_fields(structure: *const Struct, offset: u32) -> Vec<&'static Property> {
     let mut properties: Vec<&Property> = (*structure)
         .iter_children()
         .filter(|p| p.element_size > 0)

--- a/src/dump/property_info.rs
+++ b/src/dump/property_info.rs
@@ -88,9 +88,9 @@ impl PropertyInfo {
         }
     }
 
-    pub fn as_typed_comment(&self) -> Cow<str> {
+    pub fn into_typed_comment(self) -> Cow<'static, str> {
         if self.comment.is_empty() {
-            Cow::Borrowed(&self.field_type)
+            self.field_type
         } else {
             Cow::Owned(format!("{} /* {} */", self.field_type, self.comment))
         }

--- a/src/dump/property_info.rs
+++ b/src/dump/property_info.rs
@@ -87,6 +87,14 @@ impl PropertyInfo {
             comment: "".into(),
         }
     }
+
+    pub fn as_typed_comment(&self) -> Cow<str> {
+        if self.comment.is_empty() {
+            Cow::Borrowed(&self.field_type)
+        } else {
+            Cow::Owned(format!("{} /* {} */", self.field_type, self.comment))
+        }
+    }
 }
 
 impl TryFrom<&Property> for PropertyInfo {

--- a/src/game.rs
+++ b/src/game.rs
@@ -196,6 +196,15 @@ impl DerefMut for Struct {
     }
 }
 
+impl Struct {
+    pub unsafe fn iter_children(&self) -> impl Iterator<Item = &Property> {
+        iter::successors(
+            self.children.cast::<Property>().as_ref(),
+            |property| property.next.cast::<Property>().as_ref(),
+        )
+    }
+}
+
 pub type FString = Array<u16>; // &[u16] -> OsString -> Cow<str>
 
 impl FString {

--- a/src/game.rs
+++ b/src/game.rs
@@ -303,6 +303,13 @@ impl DerefMut for Function {
     }
 }
 
+impl Function {
+    pub fn is_native(&self) -> bool {
+        const NATIVE: u32 = 0x400;
+        self.flags & NATIVE == NATIVE
+    }
+}
+
 #[repr(C)]
 pub struct State {
     pub struct_base: Struct,

--- a/src/game.rs
+++ b/src/game.rs
@@ -371,6 +371,23 @@ impl DerefMut for Property {
     }
 }
 
+impl Property {
+    pub fn is_return_param(&self) -> bool {
+        const RETURN_PARAM: u32 = 0x400;
+        self.property_flags_0 & RETURN_PARAM == RETURN_PARAM
+    }
+    
+    pub fn is_out_param(&self) -> bool {
+        const OUT_PARAM: u32 = 0x100;
+        self.property_flags_0 & OUT_PARAM == OUT_PARAM
+    }
+
+    pub fn is_param(&self) -> bool {
+        const PARAM: u32 = 0x80;
+        self.property_flags_0 & PARAM == PARAM
+    }    
+}
+
 #[repr(C)]
 pub struct ByteProperty {
     pub property: Property,

--- a/src/hook/user/mod.rs
+++ b/src/hook/user/mod.rs
@@ -30,7 +30,7 @@ pub unsafe fn process_event(this: *mut Object, method: *mut Function, parameters
 
 unsafe fn my_post_render(canvas: *mut *mut Canvas) {
     let canvas = *canvas;
-    (*canvas).SetPos(100.0, 100.0, 0.0);
+    (*canvas).SetPos(200.0, 200.0, 0.0);
     (*canvas).DrawBox(200.0, 200.0);
 }
 

--- a/src/hook/user/mod.rs
+++ b/src/hook/user/mod.rs
@@ -46,7 +46,7 @@ unsafe fn my_player_destroyed() {
     info!("Destroyed CONTROLLER.");
 }
 
-fn print_event(object: &Object, method: &Function) {
+fn _print_event(object: &Object, method: &Function) {
     if let Some(object) = unsafe { object.full_name() } {
         if let Some(method) = unsafe { method.full_name() } {
             info!("{} called {}", object, method);

--- a/src/hook/user/mod.rs
+++ b/src/hook/user/mod.rs
@@ -1,4 +1,4 @@
-use crate::game::{cast, Function, Object};
+use crate::game::{Function, Object};
 use crate::hook::sdk::{Canvas, WillowPlayerController};
 
 use super::CACHED_FUNCTION_INDEXES;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::pedantic)]
+#![allow(clippy::filter_map)]
 #![allow(clippy::find_map)]
 
 #[cfg(not(all(target_arch = "x86", target_os = "windows")))]


### PR DESCRIPTION
Closes #13 .

I don't like the implementation of `add_method` because it's messy and has a lot of `String` and `Vec` allocations. Dumping is still fast, though, and takes around 500 ms on my machine.

# Examples
I ran all the examples through `rustfmt`.

## No input arguments, no return type
```rust
pub unsafe fn ServerDestroy(&mut self) {
    static mut FUNCTION: Option<*mut game::Function> = None;

    if let Some(function) = FUNCTION {
        #[repr(C)]
        struct Parameters {}

        let mut p = Parameters {};

        let old_flags = (*function).flags;
        self.process_event(function, &mut p as *mut Parameters as *mut _);
        (*function).flags = old_flags;
    } else {
        FUNCTION = (*GLOBAL_OBJECTS)
            .find_mut("Function Engine.PlayerController.ServerDestroy")
            .map(|o| o.cast());
    }
}
```

I didn't take any special precaution against empty `#[repr(C)]` structures being FFI-incompatible with empty (but actually one byte) C++ structures. I believe `ProcessEvent` just ignores the `Parameters` structure when `function.num_params == 0`.

## No input arguments, single return type
```rust
pub unsafe fn IsPrimaryPlayer(&mut self) -> Option<bool> {
    static mut FUNCTION: Option<*mut game::Function> = None;

    if let Some(function) = FUNCTION {
        #[repr(C)]
        struct Parameters {
            ReturnValue: MaybeUninit<bool>,
        }

        let mut p = Parameters {
            ReturnValue: MaybeUninit::uninit(),
        };

        let old_flags = (*function).flags;
        (*function).flags |= 0x400;
        self.process_event(function, &mut p as *mut Parameters as *mut _);
        (*function).flags = old_flags;

        Some(p.ReturnValue.assume_init())
    } else {
        FUNCTION = (*GLOBAL_OBJECTS)
            .find_mut("Function Engine.PlayerController.IsPrimaryPlayer")
            .map(|o| o.cast());
        None
    }
}
```

## Input arguments, no return type
```rust
pub unsafe fn SetPos(&mut self, PosX: f32, PosY: f32, PosZ: f32) {
    static mut FUNCTION: Option<*mut game::Function> = None;

    if let Some(function) = FUNCTION {
        #[repr(C)]
        struct Parameters {
            PosX: f32,
            PosY: f32,
            PosZ: f32,
        }

        let mut p = Parameters { PosX, PosY, PosZ };

        let old_flags = (*function).flags;
        (*function).flags |= 0x400;
        self.process_event(function, &mut p as *mut Parameters as *mut _);
        (*function).flags = old_flags;
    } else {
        FUNCTION = (*GLOBAL_OBJECTS)
            .find_mut("Function Engine.Canvas.SetPos")
            .map(|o| o.cast());
    }
}
```

## Input arguments, single return type
```rust
    pub unsafe fn Project(&mut self, Location: Vector) -> Option<Vector> {
        static mut FUNCTION: Option<*mut game::Function> = None;

        if let Some(function) = FUNCTION {
            #[repr(C)]
            struct Parameters {
                Location: Vector,
                ReturnValue: MaybeUninit<Vector>,
            }

            let mut p = Parameters {
                Location,
                ReturnValue: MaybeUninit::uninit(),
            };

            let old_flags = (*function).flags;
            (*function).flags |= 0x400;
            self.process_event(function, &mut p as *mut Parameters as *mut _);
            (*function).flags = old_flags;

            Some(p.ReturnValue.assume_init())
        } else {
            FUNCTION = (*GLOBAL_OBJECTS)
                .find_mut("Function Engine.Canvas.Project")
                .map(|o| o.cast());
            None
        }
    }
```

## Input arguments, multiple return types
```rust
pub unsafe fn DeProject(&mut self, ScreenPos: Vector2D) -> Option<(Vector, Vector)> {
    static mut FUNCTION: Option<*mut game::Function> = None;

    if let Some(function) = FUNCTION {
        #[repr(C)]
        struct Parameters {
            ScreenPos: Vector2D,
            WorldOrigin: MaybeUninit<Vector>,
            WorldDirection: MaybeUninit<Vector>,
        }

        let mut p = Parameters {
            ScreenPos,
            WorldOrigin: MaybeUninit::uninit(),
            WorldDirection: MaybeUninit::uninit(),
        };

        let old_flags = (*function).flags;
        (*function).flags |= 0x400;
        self.process_event(function, &mut p as *mut Parameters as *mut _);
        (*function).flags = old_flags;

        Some((p.WorldOrigin.assume_init(), p.WorldDirection.assume_init()))
    } else {
        FUNCTION = (*GLOBAL_OBJECTS)
            .find_mut("Function Engine.Canvas.DeProject")
            .map(|o| o.cast());
        None
    }
}
```
Technically, multiple return types are optional, but `ProcessEvent` calculates them anyway, and the consumer of the generated SDK can simply ignore return values they don't care about by using pattern matching, e.g., `let (_, dir) = canvas.DeProject(screen_pos)`.
______________________________________________________________________________________________________________________________
Implementing #13 makes me want to write a streaming code generator crate instead of using `codegen`.

Dumping is naturally a streaming process: you read the game structures from memory, cushion those structures into Rust syntax, and dump the code to `sdk.rs`. Sure, you do need to allocate some `HashMap<&str, u8>`s to create unique enum variants and identifiers, and sure, you need a `Vec` to keep track of bitfields, common enum variant prefixes, and method parameters, but on the whole, the bulk algorithm doesn't need to store previous states. Once you're done cushioning a structure, you can write to `sdk.rs` and start processing the next structure, forgetting about the previous.

`codegen` retains state of a created [`Scope`](https://docs.rs/codegen/0.1.3/src/codegen/lib.rs.html#36-45). My `sdk.rs` is a single, large `Scope`. As I stream structures, that `Scope` grows. I dump the `Scope` into a `String` that gets dumped to `sdk.rs`. Along the way, `Scope` will allocate its own `String`s and `Vec`s to keep track of enum variants, method parameters, etc. We don't need an intermediary `Scope` to keep state for us. We don't want this persistent state at all.

Another reason I want to write a streaming code generator is that I wouldn't need to allocate `String`s for formatting purposes. I could write directly to the wrapped stream using `write!`.

For example, right now, if I want to emit an array type, I'd have to do something like:

```rust
let array_type  = format!("[{}; {}]", element_type, array_dim);
codegen_struct.field(array_name, array_type); // behind-the-scenes, allocate String and append to a Vec.
```

When I really want to do something like:
```rust
write!(&mut sdk, "[{}; {}]", element_type, array_dim)?;
```

Where `sdk` is an in-memory structure or a `BufWriter<File>` or generally anything that implements `io::Write` or `fmt::Write`.

Of course one of the biggest advantages of `codegen` is the automatic formatting, especially indenting in nested blocks. So if I wanted to replace `codegen`, I'd have to create some sort of abstraction on top of the raw `write!` calls, other I'd be seeing a soup of `\n` and `    ` (indent) in format strings.