### PR TITLE
Split sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
 Cargo.lock
 .vs
-src/hook/sdk.rs
+src/hook/sdk
 sample_events.txt

--- a/src/dump/helper.rs
+++ b/src/dump/helper.rs
@@ -31,7 +31,7 @@ pub unsafe fn resolve_duplicate(object: *const Object) -> Result<Cow<'static, st
 
     let name = get_name(object)?;
 
-    if DUPLICATES.iter().any(|dup| name == *dup) {
+    if DUPLICATES.contains(&name) {
         let mut module = None;
         let mut submodule = None;
 

--- a/src/dump/helper.rs
+++ b/src/dump/helper.rs
@@ -15,6 +15,9 @@ pub enum Error {
 
     #[error("unable to find static class for \"{0}\"")]
     StaticClassNotFound(&'static str),
+
+    #[error("unknown package for {0:?}")]
+    UnknownPackage(*const Object),
 }
 
 pub unsafe fn resolve_duplicate(object: *const Object) -> Result<Cow<'static, str>, Error> {
@@ -59,4 +62,11 @@ pub unsafe fn find(class: &'static str) -> Result<*const Class, Error> {
         .find(class)
         .map(|o| o.cast())
         .ok_or(Error::StaticClassNotFound(class))?)
+}
+
+pub unsafe fn get_package(object: *const Object) -> Result<*const Object, Error> {
+    (*object)
+        .package()
+        .map(|package| package as *const Object)
+        .ok_or(Error::UnknownPackage(object))
 }

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -296,7 +296,7 @@ impl Generator {
             Some(super_name)
         };
     
-        let name = helper::get_name(object)?;
+        let name = helper::resolve_duplicate(object)?;
 
         let bitfields = {
 

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -105,8 +105,14 @@ impl Generator {
                 let name = unsafe { helper::get_name(package)? };
                 let mut name = name.to_snake_case();
 
-                self.root_mod_rs.line(format_args!("mod {module};\npub use {module}::*;\n", module=name))?;
-                
+                self.root_mod_rs.line(format_args!("mod {};", name))?;
+
+                if name == "core" {
+                    self.root_mod_rs.line(format_args!("pub use self::{}::*;\n", name))?;
+                } else {
+                    self.root_mod_rs.line(format_args!("pub use {}::*;\n", name))?;
+                }
+
                 name += ".rs";
 
                 let mut file = create_file(self.sdk_path, name)?;

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -127,11 +127,17 @@ impl Generator {
 
     fn add_crate_attributes(&mut self) -> Result<(), Error> {
         self.root_mod_rs.line(
-            "#![allow(bindings_with_variant_name)]\n\
-             #![allow(clippy::doc_markdown)]\n\
-             #![allow(dead_code)]\n\
-             #![allow(non_camel_case_types)]\n\
-             #![allow(non_snake_case)]\n",
+           "#![allow(bindings_with_variant_name)]\n\
+            #![allow(clippy::doc_markdown)]\n\
+            #![allow(clippy::fn_params_excessive_bools)]\n\
+            #![allow(clippy::module_name_repetitions)]\n\
+            #![allow(clippy::too_many_arguments)]\n\
+            #![allow(clippy::type_complexity)]\n\
+            #![allow(clippy::used_underscore_binding)]\n\
+            #![allow(clippy::wildcard_imports)]\n\
+            #![allow(dead_code)]\n\
+            #![allow(non_camel_case_types)]\n\
+            #![allow(non_snake_case)]\n"
         )?;
         Ok(())
     }

--- a/src/game.rs
+++ b/src/game.rs
@@ -116,6 +116,10 @@ impl Object {
         iter::successors(Some(self), |current| current.outer.as_ref())
     }
 
+    pub unsafe fn package(&self) -> Option<&Self> {
+        self.iter_outer().last()
+    }
+
     pub unsafe fn iter_class(&self) -> impl Iterator<Item = &Class> {
         iter::successors(self.class.as_ref(), |current| {
             current


### PR DESCRIPTION
Closes #16 .

The original ticket envisioned one `.rs` file per enum,  structure, and class.
I originally implemented that split. 
`cargo build` ballooned in memory and the build took longer than a single `.sdk`.

So I changed the split for this pull request.
We now generate one `.rs` per Unreal package.
For BLPS, there are 10 Unreal packages, and the generator created 10 `.rs` files along with the top-level `mod.rs` described in #16 that declares and re-exports the modules.

`cargo clean` followed by `cargo build` takes 1m 37s.
`cargo clean` followed by `cargo build --release` takes 2m 13s.

An incremental change followed by `cargo build` takes 16.38 s.
An incremental change followed by `cargo build --release` takes 50.81 s (`incremental = false` in Cargo.toml)
